### PR TITLE
Set gin to release mode but keep logging

### DIFF
--- a/cmd/run-webserver/main.go
+++ b/cmd/run-webserver/main.go
@@ -21,7 +21,12 @@ func main() {
 	SetupFPGA()
 	defer CleanupFPGA()
 
+	//remove release mode warning
+	gin.SetMode(gin.ReleaseMode)
 	r := gin.Default()
+	//retain logging of requests
+	r.Use(gin.Logger())
+
 	r.GET("/", func(c *gin.Context) {
 		c.Header("Content-type", "text/html")
 		c.String(200, webTemplate)


### PR DESCRIPTION
This sets gin to release mode in order to silence the debug mode warning, but then tells gin to use the standard logger anyway so we keep the logging of requests.